### PR TITLE
Add uploadId field to server events

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,8 @@ function SocketIOFile(socket, options) {
 				uploadDir: uploadingFiles[id].uploadDir,
 				data: uploadingFiles[id].data,
 				mime: mimeType,
-				estimated: endTime - startTime
+				estimated: endTime - startTime,
+				uploadId: id
 			};
 			
 			if(this.accepts && this.accepts.length > 0) {
@@ -228,7 +229,8 @@ function SocketIOFile(socket, options) {
 					size: uploadingFiles[id].size, 
 					wrote: uploadingFiles[id].wrote,
 					uploadDir: uploadingFiles[id].uploadDir,
-					data: uploadingFiles[id].data
+					data: uploadingFiles[id].data,
+					uploadId: id
 				});
 
 				if(!writeDone) {
@@ -259,7 +261,8 @@ function SocketIOFile(socket, options) {
 				size: uploadingFiles[id].size, 
 				wrote: uploadingFiles[id].wrote,
 				uploadDir: uploadingFiles[id].uploadDir,
-				data: uploadingFiles[id].data
+				data: uploadingFiles[id].data,
+				uploadId: id
 			});
 			socket.emit(`socket.io-file::abort::${id}`, {
 				name: uploadingFiles[id].name, 


### PR DESCRIPTION
This allows other code server side to link an specific upload with other parts of the codeflow.

We needed this because our flow doesn't end on the finishing of the upload.  The server executes other actions on the uploaded file and then it notifies the client back.  We needed to attach the `uploadId` to this notification so the client knows to which upload it belongs to.  So in our, server-side, `complete` event we now receive the `uploadId` property in the `fileInfo` object.